### PR TITLE
fix: pre-merge blockers + hardening (2nd review) → into agent-runtime-migration

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -24,6 +24,16 @@ concurrency:
 jobs:
   deploy:
     runs-on: self-hosted
+    # Gate on the GitHub Environment matching the selected stack. Configure
+    # required reviewers on the `prd` environment (Settings → Environments) so
+    # a prod `run-all apply -auto-approve` — which DESTROYS the old agent Cloud
+    # Run service + SA + IAM (the rollback target) and overwrites the live
+    # Firestore ruleset — cannot fire without a human approval. Leave `dev`
+    # ungated for fast iteration. Mirrors deploy-agents.yml.
+    # NOTE: cicd/modules/backend/main.tf requires a manual `terraform state rm`
+    # of the retired resources BEFORE this apply; that step is the reviewer's
+    # responsibility and must not be run from CI.
+    environment: ${{ inputs.environment }}
     env:
       ENVIRONMENT: ${{ inputs.environment }}
     steps:

--- a/agents/deploy.py
+++ b/agents/deploy.py
@@ -181,6 +181,21 @@ def main() -> None:
             "Did the 'Load runtime env vars from Secret Manager' step run?"
         )
     project = f"agro-extension-digital-{args.env}"
+    # The agent modules bake their datastore/RAG resource names from
+    # GOOGLE_CLOUD_PROJECT at import time (agent_*_app/agent.py:_datastore),
+    # while the deploy target is derived independently from --env. If the two
+    # disagree we'd ship an engine into `project` whose RAG paths point at a
+    # different project (cross-project leak / PermissionDenied at query time).
+    # Fail fast on a mismatch; otherwise pin the var to the target so a manual
+    # run with it unset can't KeyError on import either.
+    env_project = os.environ.get("GOOGLE_CLOUD_PROJECT")
+    if env_project and env_project != project:
+        raise SystemExit(
+            f"GOOGLE_CLOUD_PROJECT ({env_project!r}) does not match the --env "
+            f"target project ({project!r}). Refusing to deploy an engine whose "
+            "datastore/RAG paths would point at a different project."
+        )
+    os.environ["GOOGLE_CLOUD_PROJECT"] = project
     location = os.environ.get("GOOGLE_CLOUD_LOCATION", "us-central1")
     bucket = f"gs://{project}-agent-engine-staging"
     vertexai.init(project=project, location=location, staging_bucket=bucket)

--- a/agents/tests/test_deploy.py
+++ b/agents/tests/test_deploy.py
@@ -330,6 +330,8 @@ def test_main_happy_path_deploys_both_agents(monkeypatch):
         "BIGQUERY_DATASET": "bq",
     }.items():
         monkeypatch.setenv(k, v)
+    # The workflow exports GOOGLE_CLOUD_PROJECT matching --env; mirror that.
+    monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "agro-extension-digital-prd")
     monkeypatch.setattr("sys.argv", ["deploy.py", "--env", "prd"])
     init = MagicMock()
     monkeypatch.setattr(deploy.vertexai, "init", init)
@@ -349,3 +351,30 @@ def test_main_happy_path_deploys_both_agents(monkeypatch):
     assert (
         "agent-aa-runtime@agro-extension-digital-prd.iam.gserviceaccount.com" in sas
     )
+
+
+def test_main_aborts_when_project_env_mismatches_target(monkeypatch):
+    """A manual run whose GOOGLE_CLOUD_PROJECT disagrees with --env must abort
+    before any deploy — the agent modules bake datastore/RAG paths from that
+    env var, so a mismatch would ship a cross-project engine."""
+    import deploy
+    for k, v in {
+        "DATASTORE_AA_ID": "a", "DATASTORE_PP_ID": "b", "DATASTORE_GUIDES_ID": "c",
+        "DATASTORE_FAQ_ID": "d", "DATASTORE_CHILEPRUNES_CL_ID": "e",
+        "BIGQUERY_DATASET": "bq",
+    }.items():
+        monkeypatch.setenv(k, v)
+    # Target prd, but the environment still points at npe.
+    monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "agro-extension-digital-npe")
+    monkeypatch.setattr("sys.argv", ["deploy.py", "--env", "prd"])
+    init = MagicMock()
+    monkeypatch.setattr(deploy.vertexai, "init", init)
+    deploy_one = MagicMock()
+    monkeypatch.setattr(deploy, "deploy_one", deploy_one)
+
+    with pytest.raises(SystemExit) as exc:
+        deploy.main()
+
+    assert "does not match" in str(exc.value)
+    init.assert_not_called()
+    deploy_one.assert_not_called()

--- a/cicd/modules/backend/main.tf
+++ b/cicd/modules/backend/main.tf
@@ -49,6 +49,12 @@ resource "google_cloud_run_v2_service" "cloud_run_name_webhook" {
         value = var.verify_token
       }
       env {
+        # Read by the webhook's fail-closed X-Hub-Signature-256 validation
+        # (api/webhooks.py). Must be set or every inbound POST is rejected 403.
+        name  = "WHATSAPP_APP_SECRET"
+        value = var.whatsapp_app_secret
+      }
+      env {
         name  = "ESTANDAR_AA_APP_NAME"
         value = var.estandar_aa_app_name
       }

--- a/cicd/modules/backend/tests/security.tftest.hcl
+++ b/cicd/modules/backend/tests/security.tftest.hcl
@@ -26,6 +26,7 @@ variables {
   estandar_aa_facebook_app                 = "aa-fb"
   estandar_pp_facebook_app                 = "pp-fb"
   verify_token                             = "dummy-verify-token"
+  whatsapp_app_secret                      = "dummy-app-secret"
   service_account_webhook_app              = "webhook-sa"
   service_account_display_name_webhook_app = "Webhook SA"
   estandar_aa_app_name                     = "aa-app"

--- a/cicd/modules/backend/variables.tf
+++ b/cicd/modules/backend/variables.tf
@@ -33,6 +33,12 @@ variable "verify_token" {
   type        = string
 }
 
+variable "whatsapp_app_secret" {
+  description = "Meta App Secret usado para validar la firma X-Hub-Signature-256 de los webhooks entrantes. El webhook rechaza (403) todo POST si no está seteado (fail-closed)."
+  type        = string
+  sensitive   = true
+}
+
 variable "service_account_webhook_app" {
   description = "Cuenta de servicio para el webhook"
   type        = string

--- a/cicd/stacks/dev/backend/terragrunt.hcl
+++ b/cicd/stacks/dev/backend/terragrunt.hcl
@@ -74,9 +74,13 @@ inputs = {
   datastore_chileprunes_cl_id = local.datastores.chileprunes
 
   # Secrets y tokens
-  wsp_token         = run_cmd("gcloud", "secrets", "versions", "access", "latest", "--secret=wsp-token", "--project=${local.project_id}")
-  verify_token      = run_cmd("gcloud", "secrets", "versions", "access", "latest", "--secret=webhook-verify-token", "--project=${local.project_id}")
-  whatsapp_base_url = local.common_vars.urls.whatsapp_base
+  # NOTA: el secret `whatsapp-app-secret` debe existir en Secret Manager del
+  # proyecto antes del primer apply (igual que wsp-token / webhook-verify-token).
+  # Sin él, el webhook rechaza todos los POST con 403 (validación fail-closed).
+  wsp_token           = run_cmd("gcloud", "secrets", "versions", "access", "latest", "--secret=wsp-token", "--project=${local.project_id}")
+  verify_token        = run_cmd("gcloud", "secrets", "versions", "access", "latest", "--secret=webhook-verify-token", "--project=${local.project_id}")
+  whatsapp_app_secret = run_cmd("gcloud", "secrets", "versions", "access", "latest", "--secret=whatsapp-app-secret", "--project=${local.project_id}")
+  whatsapp_base_url   = local.common_vars.urls.whatsapp_base
 
   # Configuración específica del entorno desde env.yaml
   log_level         = local.env_vars.environment.log_level

--- a/cicd/stacks/prd/backend/terragrunt.hcl
+++ b/cicd/stacks/prd/backend/terragrunt.hcl
@@ -75,9 +75,13 @@ inputs = {
   datastore_chileprunes_cl_id = local.datastores.chileprunes
 
   # Secrets y tokens (proyecto PRD)
-  wsp_token         = run_cmd("gcloud", "secrets", "versions", "access", "latest", "--secret=wsp-token", "--project=${local.project_id}")
-  verify_token      = run_cmd("gcloud", "secrets", "versions", "access", "latest", "--secret=webhook-verify-token", "--project=${local.project_id}")
-  whatsapp_base_url = local.common_vars.urls.whatsapp_base
+  # NOTA: el secret `whatsapp-app-secret` debe existir en Secret Manager del
+  # proyecto antes del primer apply (igual que wsp-token / webhook-verify-token).
+  # Sin él, el webhook rechaza todos los POST con 403 (validación fail-closed).
+  wsp_token           = run_cmd("gcloud", "secrets", "versions", "access", "latest", "--secret=wsp-token", "--project=${local.project_id}")
+  verify_token        = run_cmd("gcloud", "secrets", "versions", "access", "latest", "--secret=webhook-verify-token", "--project=${local.project_id}")
+  whatsapp_app_secret = run_cmd("gcloud", "secrets", "versions", "access", "latest", "--secret=whatsapp-app-secret", "--project=${local.project_id}")
+  whatsapp_base_url   = local.common_vars.urls.whatsapp_base
 
   # Configuración específica del entorno desde env.yaml
   log_level         = local.env_vars.environment.log_level

--- a/webhook-application/tests/test_messages.py
+++ b/webhook-application/tests/test_messages.py
@@ -212,6 +212,34 @@ async def test_background_task_exception_is_logged_via_done_callback(caplog):
 
 
 @pytest.mark.asyncio
+async def test_cancelled_background_task_does_not_raise_in_callback(caplog):
+    """Cancellation (e.g. Cloud Run evicting the worker) is not a processing
+    failure: the done-callback must skip it, not call t.exception() and let a
+    CancelledError escape into asyncio's 'Exception in callback' handler."""
+    started = asyncio.Event()
+
+    async def _hang(body, app_name):
+        started.set()
+        await asyncio.Event().wait()  # never completes until cancelled
+
+    with patch.object(messages, "_process_webhook_in_background", _hang), \
+         caplog.at_level("ERROR"):
+        await messages.process_incoming_webhook_payload({"entry": []}, AA)
+        await started.wait()
+        (task,) = tuple(messages._background_tasks)
+        task.cancel()
+        # Let cancellation propagate and the done-callback settle.
+        for _ in range(4):
+            await asyncio.sleep(0)
+
+    assert "Exception in callback" not in caplog.text
+    assert "CancelledError" not in caplog.text
+    assert "Background webhook processing failed" not in caplog.text
+    # The callback still discards the task from the retention set.
+    assert len(messages._background_tasks) == 0
+
+
+@pytest.mark.asyncio
 async def test_process_webhook_in_background_parses_and_dispatches():
     payload = {
         "object": "whatsapp_business_account",

--- a/webhook-application/tests/test_webhooks.py
+++ b/webhook-application/tests/test_webhooks.py
@@ -81,6 +81,24 @@ def test_signature_over_wrong_secret_returns_403(client):
     assert resp.status_code == 403
 
 
+def test_non_ascii_signature_header_returns_403_not_500(client):
+    """A non-ASCII signature header must fail closed (403), not crash (500).
+
+    hmac.compare_digest raises TypeError on str operands with non-ASCII chars;
+    the header is attacker-controlled, so validation compares on bytes.
+    """
+    body = b'{"entry": []}'
+    # On the wire headers are raw bytes; Starlette decodes them latin-1, so a
+    # byte > 0x7f yields a non-ASCII str (here '\xf1'). Send raw bytes to
+    # exercise that path — a plain str header would be rejected by the client.
+    resp = client.post(
+        "/estandar_aa_webhook",
+        content=body,
+        headers={"X-Hub-Signature-256": b"sha256=\xf1oo-not-ascii"},
+    )
+    assert resp.status_code == 403
+
+
 def test_app_secret_unset_fails_closed_403(client, monkeypatch):
     """No configured app secret must reject every POST (fail-closed)."""
     monkeypatch.setattr(config, "app_secret", None)

--- a/webhook-application/whatsapp_webhook/api/webhooks.py
+++ b/webhook-application/whatsapp_webhook/api/webhooks.py
@@ -31,7 +31,10 @@ async def _verify_webhook(app_name: str, params: QueryParams) -> PlainTextRespon
     if (
         mode == "subscribe"
         and token is not None
-        and hmac.compare_digest(token, verify_token)
+        # Compare on bytes: token is attacker-controlled and a non-ASCII value
+        # would make str-operand compare_digest raise TypeError (500) instead
+        # of failing verification cleanly.
+        and hmac.compare_digest(token.encode("utf-8"), verify_token.encode("utf-8"))
     ):
         if not challenge or not challenge.isdigit():
             logger.log_webhook_verification(app_name, mode or "None", False, log_extra)
@@ -65,7 +68,10 @@ def _verify_signature(raw_body: bytes, signature_header: str | None) -> bool:
     expected = "sha256=" + hmac.new(
         app_secret.encode("utf-8"), raw_body, hashlib.sha256
     ).hexdigest()
-    return hmac.compare_digest(expected, signature_header)
+    # Compare on bytes: hmac.compare_digest raises TypeError on str operands
+    # containing non-ASCII, and signature_header is attacker-controlled. On
+    # bytes it stays constant-time and simply returns False for a mismatch.
+    return hmac.compare_digest(expected.encode("utf-8"), signature_header.encode("utf-8"))
 
 
 async def _handle_webhook_post(app_name: str, handler_func, request: Request) -> JSONResponse:

--- a/webhook-application/whatsapp_webhook/messages.py
+++ b/webhook-application/whatsapp_webhook/messages.py
@@ -93,6 +93,12 @@ async def process_incoming_webhook_payload(body: dict, app_name: str) -> bool:
 
     def _on_done(t: asyncio.Task) -> None:
         _background_tasks.discard(t)
+        # A cancelled task (e.g. Cloud Run evicting the worker mid-message)
+        # makes t.exception() itself raise CancelledError out of this
+        # callback, which asyncio then logs as a spurious "Exception in
+        # callback". Cancellation is not a processing failure — skip it.
+        if t.cancelled():
+            return
         exc = t.exception()
         if exc is not None:
             logging.error(


### PR DESCRIPTION
Fixes from the **second review** of #43, branched off `feature/agent-runtime-migration` so they land *into* that PR before it merges to `main`. @robertosolargallardo please review / approve / merge here.

## 🔴 Blockers (would break the deploy)

**1. `WHATSAPP_APP_SECRET` was never provisioned → 100% of webhooks 403.**
The new signature gate in `api/webhooks.py` is mandatory and fail-closed, but `WHATSAPP_APP_SECRET` existed nowhere in infra (no variable, no Cloud Run env, no Terragrunt input). On deploy, `config.app_secret is None` → every inbound WhatsApp POST returns 403 (this would fail the npe smoke test itself).
- New `whatsapp_app_secret` variable (`sensitive`) in `cicd/modules/backend/variables.tf`
- `WHATSAPP_APP_SECRET` env entry on the webhook Cloud Run service in `main.tf`
- Sourced via `run_cmd` from a `whatsapp-app-secret` Secret Manager secret in **both** dev and prd stacks, mirroring `wsp-token` / `webhook-verify-token`.
- ⚠️ **Operator action:** create the `whatsapp-app-secret` secret (the real Meta App Secret) in both `agro-extension-digital-npe` and `-prd` **before** the first `terragrunt apply` — same bootstrap requirement as the existing token secrets.

**2. `deploy.yaml` ran `run-all apply -auto-approve` ungated.**
The prd run destroys the old agent Cloud Run service + SA + IAM (the rollback target) and overwrites the live Firestore ruleset, with no reviewer gate. Bound the job to `environment: ${{ inputs.environment }}` so **required reviewers on the `prd` GitHub Environment must approve** before apply; `dev` stays ungated for fast iteration (mirrors `deploy-agents.yml`).
- ⚠️ **Operator action:** configure required reviewers on the `prd` environment (Settings → Environments). The pre-apply `terraform state rm` of retired resources remains the reviewer's manual step (per `main.tf`'s note; must not run from CI) — called out in a workflow comment.

## 🟠 Hardening

**3. `deploy.py` — cross-project engine guard.** The agent modules bake datastore/RAG paths from `GOOGLE_CLOUD_PROJECT` at import, but the deploy target comes from `--env`. A manual run with a mismatched env would ship an engine whose RAG points at the wrong project. Now aborts on mismatch (and pins the var to the target when unset). The workflow always sets them equal, so it's a no-op there. + test.

**4. `webhooks.py` — bytes compare for signature + verify_token.** `hmac.compare_digest` raises `TypeError` (→500) on `str` operands containing non-ASCII, and both `X-Hub-Signature-256` and the GET `hub.verify_token` are attacker-controlled. Now compared on bytes → fails closed (403). + regression test over the raw-bytes wire path.

**5. `messages.py` — cancelled-task guard.** The background-task done-callback called `t.exception()` unguarded; a cancelled task (Cloud Run eviction mid-message) makes that raise `CancelledError` into asyncio's callback handler. Guarded with `if t.cancelled(): return`. + test.

## Verification
- `agents/`: **45 passed** (`uv run pytest tests/`)
- `webhook-application/`: **91 passed** (`uv run --extra test pytest tests/`)
- `terraform fmt` (backend module) + `terragrunt hcl format` (both backend stacks): clean

## Not included (flagged, left for a decision)
- `deploy.py` disable-version path can orphan/duplicate an engine on operator rollback (edge case).
- Firestore create rules dereference `resource.data` (null on create) → owner self-service create denied (fails safe).
- `useSurveyAutoSave.ts` pre-existing data-loss/concurrent-write races (not introduced by #43).
- Route protection is now client-only; Firestore rules are the sole boundary and deserve an independent audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)