### PR TITLE
chore(deploy): local deploy kit to replace the offline self-hosted runner

### DIFF
--- a/docs/superpowers/runbook-agent-runtime-deploy.md
+++ b/docs/superpowers/runbook-agent-runtime-deploy.md
@@ -2,21 +2,43 @@
 
 What to do per env to deploy or redeploy the Vertex AI Agent Runtime engines and the rewritten webhook.
 
+> **Deploys now run locally, not on the runner.** The self-hosted runner is not
+> picking up jobs, so every workflow below (`deploy.yaml`, `deploy-agents.yml`,
+> `build-and-push.yml`) queues indefinitely. Use `scripts/local-deploy/`, which
+> mirrors each workflow and encodes the ordering and naming rules this document
+> describes prose-only. See `scripts/local-deploy/README.md`.
+>
+> The GitHub-dispatch instructions below are kept for when the runner returns.
+
+## Naming (three names for one environment)
+
+Getting this wrong deploys to the wrong project. `scripts/local-deploy/lib.sh`
+resolves it centrally; anything run by hand must apply it manually.
+
+| stack dir | `environment.name` | GCP project | `deploy.py --env` | Cloud Run service | image project |
+|---|---|---|---|---|---|
+| `dev` | `dev` | `agro-extension-digital-npe` | `npe` | `agent-webhook-dev` | npe |
+| `prd` | `prd` | `agro-extension-digital-prd` | `prd` | `agent-webhook-prd` | **npe** |
+
+Container images live in the **NPE** project for *both* environments
+(`cicd/stacks/common.yaml` → `containers.project`) — that is the path the backend
+Terraform points Cloud Run at in prd too.
+
 ## Prerequisites (once per environment)
 
-- `gcloud` authenticated with an account that has Owner or equivalent IAM in the target project.
-- `terraform` 1.15+, `terragrunt` 1.0+, `uv` 0.9+, `docker` (with linux/amd64 buildx support).
-- The repo secret `GCP_SA_KEY` populated with the service-account key the GitHub Actions runner uses to run `deploy-agents.yml`. That SA must have:
-  - `roles/aiplatform.admin` (engine create/update/delete)
-  - `roles/secretmanager.secretAccessor` on the six runtime-config secrets (see Phase 1 step 2 — Terraform creates them; the IAM grant for `GCP_SA_KEY`'s SA must be done out-of-band the first time)
-  - `roles/storage.admin` on the staging bucket
-  - `roles/iam.serviceAccountUser` on `agent-aa-runtime@…` and `agent-pp-runtime@…`
-- Self-hosted runner online (or convert the workflow to GitHub-hosted with Workload Identity Federation — see review F11).
+- `gcloud` authenticated with an account that has Owner or equivalent IAM in the target project — plus `gcloud auth application-default login`, which is separate and is what `deploy.py` actually uses.
+- `terraform` 1.5+ (that is all `required_version` asks for; 1.6+ only matters for `terraform test`, which is CI-only), `terragrunt` 0.78+, `uv` 0.9+, `docker` with `linux/amd64` buildx support.
+- **Four secrets must already exist in the project before the first `terragrunt plan`**, because the stack reads them with `run_cmd` while *evaluating* config: `wsp-token`, `webhook-verify-token`, `whatsapp-app-secret-aa`, `whatsapp-app-secret-pp`. Create the last two with `scripts/local-deploy/05-create-app-secrets.sh <env>`. AA and PP are separate Meta apps with distinct App Secrets.
+- Run `scripts/local-deploy/00-preflight.sh <env>` — it checks all of the above and changes nothing.
+
+For GitHub-dispatched runs (when the runner is back), the repo secret `GCP_SA_KEY` must additionally hold a service-account key with `roles/aiplatform.admin`, `roles/secretmanager.secretAccessor` on the six runtime-config secrets, `roles/storage.admin` on the staging bucket, and `roles/iam.serviceAccountUser` on `agent-aa-runtime@…` / `agent-pp-runtime@…`. Note `cicd.deployer_sa_email` is commented out in both `env.yaml` files, so Terraform currently grants that SA nothing — the bindings are inert and the IAM must be granted out-of-band.
 
 ## Phase 1 — Infra
 
+Local: `scripts/local-deploy/20-infra.sh <env> plan`, then `… apply`. By hand:
+
 ```bash
-cd cicd/stacks/<env>/backend     # <env> = dev or prd
+cd cicd/stacks/<env>/backend     # <env> = dev or prd (stack dir, not project)
 terragrunt plan -out=phase1.tfplan
 # Review the plan. Expected for a fresh prd: ~25 adds (runtime SAs, GCS staging
 # bucket, 6 runtime-config secrets + versions, engine resource-name secret
@@ -59,12 +81,11 @@ gh workflow run deploy-agents.yml -f environment=<env>
 gh run watch
 ```
 
-Or invoke locally if the runner is offline:
+Locally (the current default): `scripts/local-deploy/30-agents.sh <env>`. By hand — note `<agent-env>` is `npe` or `prd`, **not** the `dev`/`prd` stack name, and there is no `agro-extension-digital-dev` project:
 
 ```bash
-gcloud config set project agro-extension-digital-<env>
 cd agents
-export GOOGLE_CLOUD_PROJECT=agro-extension-digital-<env>
+export GOOGLE_CLOUD_PROJECT=agro-extension-digital-<agent-env>   # npe | prd
 export GOOGLE_CLOUD_LOCATION=us-central1
 export GOOGLE_GENAI_USE_VERTEXAI=TRUE
 # Pull runtime config from the secrets we just created:
@@ -73,8 +94,10 @@ for k in DATASTORE_AA_ID DATASTORE_PP_ID DATASTORE_GUIDES_ID \
   secret_id="$(echo $k | tr A-Z_ a-z- )"
   export $k="$(gcloud secrets versions access latest --secret=$secret_id)"
 done
-uv run python deploy.py --env <env>
+uv run python deploy.py --env <agent-env>          # npe | prd
 ```
+
+`deploy.py` refuses to run if `GOOGLE_CLOUD_PROJECT` disagrees with `--env`, so a stale exported project cannot point one environment's datastore/RAG paths at another environment's engine.
 
 Expected output: `agent_aa: projects/.../reasoningEngines/<id>` and `agent_pp: projects/.../reasoningEngines/<id>`. Both resource names are written back to `engine-{aa,pp}-resource-name` secrets.
 
@@ -89,25 +112,33 @@ git push origin feature/agent-runtime-migration
 gh run watch
 ```
 
-Local fallback:
+Locally (the current default):
+
+```bash
+./scripts/local-deploy/10-build-push.sh       <env> --latest
+./scripts/local-deploy/40-redeploy-webhook.sh <env>
+```
+
+By hand — the image project is **always npe**, for prd too. Pushing to a prd registry produces an image nothing pulls:
 
 ```bash
 cd webhook-application
 SHA=$(git rev-parse --short HEAD)
-IMG=us-central1-docker.pkg.dev/agro-extension-digital-<env>/agro-extension-digital/webhook
+IMG=us-central1-docker.pkg.dev/agro-extension-digital-npe/agro-extension-digital/webhook
 gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
-docker build --platform=linux/amd64 -t $IMG:$SHA -t $IMG:latest .
-docker push $IMG:$SHA
-docker push $IMG:latest
+# --platform linux/amd64 is mandatory: Cloud Run is amd64-only, and a native
+# build on Apple Silicon pushes fine then fails to start with exec-format error.
+docker buildx build --platform linux/amd64 --push -t $IMG:$SHA -t $IMG:latest .
 ```
 
-Then redeploy the Cloud Run service to pick up the new image:
+Then redeploy the Cloud Run service — pushing `:latest` alone does nothing, because Cloud Run pinned a digest at deploy time:
 
 ```bash
+# service name uses the STACK name (dev|prd); project uses npe|prd
 gcloud run services update agent-webhook-<env> \
-  --image=us-central1-docker.pkg.dev/agro-extension-digital-<env>/agro-extension-digital/webhook:$SHA \
+  --image=$IMG:$SHA \
   --region=us-central1 \
-  --project=agro-extension-digital-<env>
+  --project=agro-extension-digital-<agent-env>
 ```
 
 The env vars are already correct (Phase 1 added `GOOGLE_CLOUD_PROJECT` / `GOOGLE_CLOUD_LOCATION`).

--- a/scripts/local-deploy/00-preflight.sh
+++ b/scripts/local-deploy/00-preflight.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# Verifies this machine can run a local deploy against <dev|prd>, WITHOUT
+# changing anything. Run this first; fix everything it flags before proceeding.
+#
+#   ./scripts/local-deploy/00-preflight.sh dev
+
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
+resolve_env "${1:-}"
+use_project
+print_target
+
+fail=0
+note() { c_grn "  ✅ $*"; }
+warn() { c_ylw "  ⚠️  $*"; }
+bad()  { c_red "  ❌ $*"; fail=1; }
+
+# ── 1. Tooling ────────────────────────────────────────────────────────────────
+c_blu "1. Tooling"
+for t in gcloud terragrunt terraform uv docker; do
+  command -v "$t" >/dev/null 2>&1 || { bad "$t not installed"; continue; }
+  note "$t $("$t" --version 2>&1 | head -1)"
+done
+
+# The frontend module needs >= 1.5; nothing here needs more. (`terraform test`
+# needs 1.6+, but that only runs in CI — it is not part of a deploy.)
+if command -v terraform >/dev/null 2>&1; then
+  tf_ver="$(terraform version -json 2>/dev/null | sed -n 's/.*"terraform_version": *"\([^"]*\)".*/\1/p')"
+  tf_major="${tf_ver%%.*}"; tf_minor="$(echo "$tf_ver" | cut -d. -f2)"
+  if (( tf_major > 1 )) || (( tf_major == 1 && tf_minor >= 5 )); then
+    note "terraform ${tf_ver} satisfies required_version >= 1.5"
+  else
+    bad "terraform ${tf_ver} is below the modules' required_version >= 1.5"
+  fi
+fi
+
+# ── 2. Docker can produce linux/amd64 ────────────────────────────────────────
+c_blu "2. Docker / image architecture"
+host_arch="$(uname -m)"
+if ! docker info >/dev/null 2>&1; then
+  bad "Docker daemon is not running (start Docker Desktop)"
+elif [[ "$host_arch" == "arm64" || "$host_arch" == "aarch64" ]]; then
+  # Cloud Run only runs linux/amd64. A plain `docker build` on Apple Silicon
+  # produces an arm64 image that pushes fine and then fails to start with an
+  # exec-format error — the single worst local-deploy trap. 10-build-push.sh
+  # always passes --platform linux/amd64; this just confirms it can.
+  if docker buildx inspect --bootstrap >/dev/null 2>&1; then
+    note "host is ${host_arch}; buildx available for --platform linux/amd64"
+  else
+    bad "host is ${host_arch} but docker buildx is unavailable — images would be arm64 and Cloud Run would not start them"
+  fi
+else
+  note "host is ${host_arch}"
+fi
+
+# ── 3. gcloud identity + project access ──────────────────────────────────────
+c_blu "3. Authentication"
+active="$(gcloud auth list --filter=status:ACTIVE --format='value(account)' 2>/dev/null || true)"
+[[ -n "$active" ]] && note "active account: ${active}" || bad "no active gcloud account (run: gcloud auth login)"
+
+if gcloud projects describe "$PROJECT_ID" >/dev/null 2>&1; then
+  note "can read project ${PROJECT_ID}"
+else
+  bad "cannot access project ${PROJECT_ID} as ${active}"
+fi
+
+# deploy.py (Vertex AI SDK) authenticates via Application Default Credentials,
+# which are SEPARATE from `gcloud auth login`. Missing ADC is a common surprise:
+# gcloud works, then deploy.py dies with DefaultCredentialsError.
+adc="${HOME}/.config/gcloud/application_default_credentials.json"
+if [[ -f "$adc" ]]; then
+  note "ADC present (needed by agents/deploy.py)"
+else
+  bad "no ADC — run: gcloud auth application-default login"
+fi
+
+# ── 4. Secrets that must pre-exist ───────────────────────────────────────────
+c_blu "4. Pre-existing secrets (read by terragrunt run_cmd at PLAN time)"
+for s in "${PREEXISTING_SECRETS[@]}"; do
+  if gcloud secrets versions access latest --secret="$s" --project="$PROJECT_ID" >/dev/null 2>&1; then
+    note "${s}"
+  else
+    bad "${s} missing or unreadable — terragrunt plan will fail before it starts"
+  fi
+done
+
+# ── 5. Terraform-managed secrets (informational) ─────────────────────────────
+c_blu "5. Terraform-managed secrets (created by 20-infra.sh, not by you)"
+for s in datastore-aa-id datastore-pp-id datastore-guides-id datastore-faq-id \
+         datastore-chileprunes-cl-id bigquery-dataset; do
+  if gcloud secrets describe "$s" --project="$PROJECT_ID" >/dev/null 2>&1; then
+    note "${s} exists"
+  else
+    warn "${s} absent — expected before the first infra apply"
+  fi
+done
+for s in engine-aa-resource-name engine-pp-resource-name; do
+  if gcloud secrets versions access latest --secret="$s" --project="$PROJECT_ID" >/dev/null 2>&1; then
+    note "${s} has a version (engines already deployed)"
+  elif gcloud secrets describe "$s" --project="$PROJECT_ID" >/dev/null 2>&1; then
+    warn "${s} exists but is EMPTY — the webhook 500s until 30-agents.sh seeds it"
+  else
+    warn "${s} absent — created by the infra apply"
+  fi
+done
+
+echo
+if (( fail )); then
+  c_red "PREFLIGHT FAILED — fix the ❌ items above before deploying."
+  exit 1
+fi
+c_grn "PREFLIGHT PASSED for ${STACK} (${PROJECT_ID})."

--- a/scripts/local-deploy/00-preflight.sh
+++ b/scripts/local-deploy/00-preflight.sh
@@ -69,6 +69,17 @@ fi
 adc="${HOME}/.config/gcloud/application_default_credentials.json"
 if [[ -f "$adc" ]]; then
   note "ADC present (needed by agents/deploy.py)"
+  # The database unit's firebaserules calls fail under user ADC unless a quota
+  # project is set (20-infra.sh also forces it via GOOGLE_BILLING_PROJECT, but a
+  # set quota project is the durable fix and avoids a confusing first run).
+  qp="$(python3 -c "import json,sys;print(json.load(open('$adc')).get('quota_project_id',''))" 2>/dev/null || true)"
+  if [[ "$qp" == "$PROJECT_ID" ]]; then
+    note "ADC quota project = ${qp}"
+  elif [[ -n "$qp" ]]; then
+    warn "ADC quota project is ${qp}, not ${PROJECT_ID} — run: gcloud auth application-default set-quota-project ${PROJECT_ID}"
+  else
+    warn "ADC has no quota project — run: gcloud auth application-default set-quota-project ${PROJECT_ID}"
+  fi
 else
   bad "no ADC — run: gcloud auth application-default login"
 fi

--- a/scripts/local-deploy/05-create-app-secrets.sh
+++ b/scripts/local-deploy/05-create-app-secrets.sh
@@ -7,8 +7,12 @@
 # AA and PP are SEPARATE Meta apps with distinct App Secrets, so each webhook
 # endpoint verifies against its own. Get each value from:
 #   developers.facebook.com → the app → Settings → Basic → App Secret → Show
-#     AA app id: 692894087240362
-#     PP app id: 619189944620159
+#     AA Meta App ID: 1328420471593056
+#     PP Meta App ID: 1611224729556662
+#
+# These are the Meta *App* IDs — what you use to locate the App Secret in the
+# console. They are NOT the numbers in cicd/stacks/*/env.yaml (those are
+# WhatsApp phone-number IDs used to build the outbound graph.facebook.com URL).
 #
 # NOTE: this is the App Secret (HMAC key for inbound signature validation), NOT
 # wsp-token (the Bearer access token used for outbound sends) and NOT
@@ -44,8 +48,8 @@ put_secret() {
   fi
 }
 
-put_secret whatsapp-app-secret-aa "AA (692894087240362)"
-put_secret whatsapp-app-secret-pp "PP (619189944620159)"
+put_secret whatsapp-app-secret-aa "AA (Meta App 1328420471593056)"
+put_secret whatsapp-app-secret-pp "PP (Meta App 1611224729556662)"
 
 echo
 c_blu "Verifying (length only — values are not printed):"

--- a/scripts/local-deploy/05-create-app-secrets.sh
+++ b/scripts/local-deploy/05-create-app-secrets.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# One-time (per environment): create the two Meta App Secrets the webhook uses
+# to validate X-Hub-Signature-256 on inbound POSTs.
+#
+#   ./scripts/local-deploy/05-create-app-secrets.sh dev
+#
+# AA and PP are SEPARATE Meta apps with distinct App Secrets, so each webhook
+# endpoint verifies against its own. Get each value from:
+#   developers.facebook.com → the app → Settings → Basic → App Secret → Show
+#     AA app id: 692894087240362
+#     PP app id: 619189944620159
+#
+# NOTE: this is the App Secret (HMAC key for inbound signature validation), NOT
+# wsp-token (the Bearer access token used for outbound sends) and NOT
+# webhook-verify-token (the string you invented for Meta's one-time GET
+# subscription handshake). Three different values; they are not interchangeable.
+#
+# Values are read with `read -s` so they are never echoed and never land in
+# shell history.
+
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
+resolve_env "${1:-}"
+use_project
+print_target
+confirm_prd
+
+put_secret() {
+  local name="$1" label="$2" value
+
+  read -r -s -p "  ${label} App Secret (input hidden, blank = skip): " value
+  echo
+  if [[ -z "$value" ]]; then c_ylw "  skipped ${name}"; return 0; fi
+
+  # printf '%s' — NOT echo — so no trailing newline is stored. A trailing \n
+  # becomes part of the HMAC key and every signature check would fail.
+  if gcloud secrets describe "$name" --project="$PROJECT_ID" >/dev/null 2>&1; then
+    printf '%s' "$value" | gcloud secrets versions add "$name" \
+      --data-file=- --project="$PROJECT_ID" >/dev/null
+    c_grn "  ✅ added new version to ${name}"
+  else
+    printf '%s' "$value" | gcloud secrets create "$name" \
+      --data-file=- --replication-policy=automatic --project="$PROJECT_ID" >/dev/null
+    c_grn "  ✅ created ${name}"
+  fi
+}
+
+put_secret whatsapp-app-secret-aa "AA (692894087240362)"
+put_secret whatsapp-app-secret-pp "PP (619189944620159)"
+
+echo
+c_blu "Verifying (length only — values are not printed):"
+for s in whatsapp-app-secret-aa whatsapp-app-secret-pp; do
+  if n=$(gcloud secrets versions access latest --secret="$s" --project="$PROJECT_ID" 2>/dev/null | wc -c | tr -d ' '); then
+    c_grn "  ${s}: ${n} bytes"
+  else
+    c_red "  ${s}: unreadable"
+  fi
+done

--- a/scripts/local-deploy/10-build-push.sh
+++ b/scripts/local-deploy/10-build-push.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Local equivalent of .github/workflows/build-and-push.yml.
+#
+#   ./scripts/local-deploy/10-build-push.sh dev [--latest] [--frontend]
+#
+# Builds and pushes the webhook image (and optionally the frontend) tagged with
+# the current short SHA. Pass --latest to ALSO move the :latest tag, which is
+# what Cloud Run pulls — mirrors the workflow's PUSH_LATEST gate, which only
+# fires on main and version tags. Omit it when you just want an immutable
+# :<sha> to test.
+#
+# Images always go to the NPE registry for BOTH environments — see lib.sh.
+
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
+resolve_env "${1:-}"; shift || true
+
+push_latest=0; do_frontend=0
+for arg in "$@"; do
+  case "$arg" in
+    --latest)   push_latest=1 ;;
+    --frontend) do_frontend=1 ;;
+    *) die "Unknown flag: $arg" ;;
+  esac
+done
+
+use_project
+print_target
+
+GIT_SHA="$(git -C "$REPO_ROOT" rev-parse --short HEAD)"
+if [[ -n "$(git -C "$REPO_ROOT" status --porcelain --untracked-files=no)" ]]; then
+  c_ylw "⚠️  Working tree has uncommitted tracked changes; :${GIT_SHA} will NOT match this build."
+fi
+echo "  building from ${GIT_SHA} on $(git -C "$REPO_ROOT" branch --show-current)"
+(( push_latest )) && c_ylw "  --latest: this WILL move the tag Cloud Run pulls."
+echo
+
+gcloud auth configure-docker "${REGION}-docker.pkg.dev" --quiet
+
+build_push() {
+  local ctx="$1" image="$2" name="$3"
+  c_blu "Building ${name}…"
+  local tags=(-t "${image}:${GIT_SHA}")
+  (( push_latest )) && tags+=(-t "${image}:latest")
+
+  # --platform linux/amd64 is MANDATORY. Cloud Run runs amd64 only; a native
+  # build on Apple Silicon yields an arm64 image that pushes successfully and
+  # then fails at startup with an exec-format error.
+  docker buildx build --platform linux/amd64 --push "${tags[@]}" "$ctx"
+
+  c_grn "  ✅ pushed ${image}:${GIT_SHA}"
+  (( push_latest )) && c_grn "  ✅ pushed ${image}:latest"
+}
+
+build_push "${REPO_ROOT}/webhook-application" "$WEBHOOK_IMAGE" "whatsapp webhook"
+(( do_frontend )) && build_push "${REPO_ROOT}/frontend" "$FRONTEND_IMAGE" "frontend"
+
+echo
+c_grn "Done. Image digest actually served:"
+docker buildx imagetools inspect "${WEBHOOK_IMAGE}:${GIT_SHA}" --format '{{.Manifest.Digest}}' 2>/dev/null || true
+echo
+echo "Next: ./scripts/local-deploy/20-infra.sh ${STACK} plan"
+echo "Or redeploy just the webhook: ./scripts/local-deploy/40-redeploy-webhook.sh ${STACK} ${GIT_SHA}"

--- a/scripts/local-deploy/20-infra.sh
+++ b/scripts/local-deploy/20-infra.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Local equivalent of .github/workflows/deploy.yaml (terragrunt run-all).
+#
+#   ./scripts/local-deploy/20-infra.sh dev plan
+#   ./scripts/local-deploy/20-infra.sh dev apply
+#
+# TWO DELIBERATE DIFFERENCES FROM THE WORKFLOW — do not "fix" them back:
+#
+# 1. Syntax. The workflow runs `terragrunt run-all <cmd> --terragrunt-non-interactive`.
+#    That flag was REMOVED in Terragrunt 0.78+ (locally: 0.99.4 → "flag provided
+#    but not defined"), and `run-all` is now the deprecated alias for `run --all`.
+#    Copying the workflow line verbatim fails immediately on a current install.
+#
+# 2. Approval. `terragrunt run --all apply` appends `-auto-approve` to the
+#    underlying terraform BY DEFAULT; `--no-auto-approve` is what restores the
+#    per-unit prompt. So the "safe" reading of the workflow is backwards — it is
+#    already unattended. The prd apply destroys the old Cloud Run agent service,
+#    its SA and IAM bindings (the rollback target) and overwrites the live
+#    Firestore ruleset. Run locally there is no GitHub Environment reviewer gate,
+#    so the plan review IS the gate, and we force the prompt.
+
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
+resolve_env "${1:-}"
+action="${2:-plan}"
+[[ "$action" == "plan" || "$action" == "apply" ]] || die "Second arg must be 'plan' or 'apply' (got '${action}')"
+
+use_project
+print_target
+
+STACK_DIR="${REPO_ROOT}/cicd/stacks/${STACK}"
+[[ -d "$STACK_DIR" ]] || die "No stack directory at ${STACK_DIR}"
+
+# terragrunt reads these secrets with run_cmd while EVALUATING the config, so a
+# missing one fails before any plan output appears — with an error that points
+# at gcloud, not at the real cause. Check up front and say so plainly.
+c_blu "Checking plan-time secret reads…"
+missing=()
+for s in "${PREEXISTING_SECRETS[@]}"; do
+  gcloud secrets versions access latest --secret="$s" --project="$PROJECT_ID" >/dev/null 2>&1 \
+    || missing+=("$s")
+done
+if (( ${#missing[@]} )); then
+  c_red "Missing secrets in ${PROJECT_ID}: ${missing[*]}"
+  die "terragrunt cannot evaluate the config. Run 05-create-app-secrets.sh ${STACK} first."
+fi
+c_grn "  ✅ all ${#PREEXISTING_SECRETS[@]} plan-time secrets readable"
+echo
+
+cd "$STACK_DIR"
+
+c_blu "terragrunt run --all init…"
+terragrunt run --all init --non-interactive
+
+c_blu "terragrunt run --all plan…"
+terragrunt run --all plan --non-interactive
+
+if [[ "$action" == "plan" ]]; then
+  echo
+  c_grn "Plan complete. Read it, then re-run with 'apply'."
+  echo
+  c_ylw "Before applying, confirm in the plan above:"
+  echo "  • Destroy count is exactly 5 on the first migration apply (old agent Cloud Run"
+  echo "    service + its SA + 2 role bindings + webhook_invokes_agent_aa). Anything else → STOP."
+  echo "  • The webhook Cloud Run service gains WHATSAPP_APP_SECRET_AA / _PP env entries."
+  echo "  • cicd/modules/backend/main.tf documents a manual 'terraform state rm' of the"
+  echo "    retired resources that must happen BEFORE this apply. Confirm it is done."
+  exit 0
+fi
+
+echo
+confirm_prd
+c_ylw "Applying to ${PROJECT_ID}. --no-auto-approve keeps the per-unit prompt."
+# NOTE: --non-interactive is deliberately absent here. It means "assume yes to
+# all prompts", which would defeat --no-auto-approve.
+terragrunt run --all apply --no-auto-approve
+
+echo
+c_grn "Infra applied."
+echo
+c_ylw "ORDERING (critical): engine-{aa,pp}-resource-name now exist but are EMPTY."
+echo "The webhook resolves the engine handle from them on every inbound message,"
+echo "so it 500s until they are seeded. Run this next, before any real traffic:"
+echo "  ./scripts/local-deploy/30-agents.sh ${STACK}"

--- a/scripts/local-deploy/30-agents.sh
+++ b/scripts/local-deploy/30-agents.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Local equivalent of .github/workflows/deploy-agents.yml.
+#
+#   ./scripts/local-deploy/30-agents.sh dev
+#
+# Creates or updates the two Vertex AI Agent Engines and writes their resource
+# names back into engine-{aa,pp}-resource-name. deploy.py is idempotent: it
+# resolves an existing engine from the secret and updates in place, so re-running
+# is safe.
+#
+# Run this AFTER 20-infra.sh (which creates the runtime-config secrets this
+# reads) and BEFORE pointing any real WhatsApp traffic at the webhook (which
+# 500s while the engine-name secrets are empty).
+
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
+resolve_env "${1:-}"
+use_project
+print_target
+confirm_prd
+
+# deploy.py refuses to run when GOOGLE_CLOUD_PROJECT disagrees with --env, so
+# that a stale exported project can't send one env's datastore/RAG paths at
+# another env's engine. use_project already set it to match; this is the value
+# that guard will check.
+export GOOGLE_CLOUD_LOCATION="$REGION"
+export GOOGLE_GENAI_USE_VERTEXAI=TRUE
+
+c_blu "Loading runtime config from Secret Manager (${PROJECT_ID})…"
+for k in DATASTORE_AA_ID DATASTORE_PP_ID DATASTORE_GUIDES_ID \
+         DATASTORE_FAQ_ID DATASTORE_CHILEPRUNES_CL_ID BIGQUERY_DATASET; do
+  secret_id="$(echo "$k" | tr 'A-Z_' 'a-z-')"
+  if ! v="$(gcloud secrets versions access latest --secret="$secret_id" --project="$PROJECT_ID" 2>/dev/null)"; then
+    die "Secret '${secret_id}' not found in ${PROJECT_ID}. Run 20-infra.sh ${STACK} apply first — Terraform creates these."
+  fi
+  export "$k=$v"
+  c_grn "  ✅ ${k}"
+done
+echo
+
+cd "${REPO_ROOT}/agents"
+c_blu "uv sync…"
+uv sync --quiet
+
+c_blu "Deploying engines (this takes several minutes per engine)…"
+uv run python deploy.py --env "$AGENT_ENV"
+
+echo
+c_blu "Verifying the engine-name secrets were seeded:"
+for s in engine-aa-resource-name engine-pp-resource-name; do
+  if v="$(gcloud secrets versions access latest --secret="$s" --project="$PROJECT_ID" 2>/dev/null)"; then
+    c_grn "  ✅ ${s} → ${v}"
+  else
+    c_red "  ❌ ${s} still EMPTY — the webhook will 500 on every message."
+    exit 1
+  fi
+done
+
+echo
+c_grn "Engines deployed."
+echo "Next: ./scripts/local-deploy/40-redeploy-webhook.sh ${STACK} <sha>"

--- a/scripts/local-deploy/40-redeploy-webhook.sh
+++ b/scripts/local-deploy/40-redeploy-webhook.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Point the webhook Cloud Run service at a specific image tag.
+#
+#   ./scripts/local-deploy/40-redeploy-webhook.sh dev 1a2b3c4
+#   ./scripts/local-deploy/40-redeploy-webhook.sh dev            # defaults to HEAD sha
+#
+# Needed because Cloud Run resolves :latest to a DIGEST at deploy time. Pushing
+# a new :latest does not restart anything — the service keeps serving the digest
+# it pinned. This forces a new revision on the tag you name.
+#
+# Deploy this only AFTER 30-agents.sh has seeded engine-{aa,pp}-resource-name.
+
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
+resolve_env "${1:-}"
+TAG="${2:-$(git -C "$REPO_ROOT" rev-parse --short HEAD)}"
+use_project
+print_target
+echo "  image tag      : ${TAG}"
+echo
+
+# Refuse to expose the webhook before the engine handles exist — this is the
+# documented cutover failure mode (access latest → NOT_FOUND → 500 per message).
+for s in engine-aa-resource-name engine-pp-resource-name; do
+  gcloud secrets versions access latest --secret="$s" --project="$PROJECT_ID" >/dev/null 2>&1 \
+    || die "${s} has no version. Run 30-agents.sh ${STACK} first, or the webhook 500s on every message."
+done
+c_grn "  ✅ engine-name secrets are seeded"
+
+gcloud artifacts docker images describe "${WEBHOOK_IMAGE}:${TAG}" --project="$IMAGE_PROJECT" >/dev/null 2>&1 \
+  || die "Image ${WEBHOOK_IMAGE}:${TAG} not found. Run 10-build-push.sh ${STACK} first."
+c_grn "  ✅ image exists"
+
+# Capture the currently-serving revision so a rollback is one command away.
+prev="$(gcloud run services describe "$CLOUD_RUN_WEBHOOK" --region="$REGION" \
+        --project="$PROJECT_ID" --format='value(status.traffic[0].revisionName)' 2>/dev/null || true)"
+[[ -n "$prev" ]] && c_blu "  current revision: ${prev}"
+
+echo
+confirm_prd
+gcloud run services update "$CLOUD_RUN_WEBHOOK" \
+  --image="${WEBHOOK_IMAGE}:${TAG}" \
+  --region="$REGION" \
+  --project="$PROJECT_ID"
+
+echo
+c_grn "Deployed ${WEBHOOK_IMAGE}:${TAG} to ${CLOUD_RUN_WEBHOOK}."
+if [[ -n "$prev" ]]; then
+  echo
+  c_ylw "Rollback (instant, no rebuild):"
+  echo "  gcloud run services update-traffic ${CLOUD_RUN_WEBHOOK} \\"
+  echo "    --to-revisions=${prev}=100 --region=${REGION} --project=${PROJECT_ID}"
+fi

--- a/scripts/local-deploy/README.md
+++ b/scripts/local-deploy/README.md
@@ -1,0 +1,72 @@
+# Local deploy kit
+
+Runs the whole deploy from a workstation instead of the self-hosted GitHub
+runner. Every script mirrors one workflow, with the workflow's implicit
+assumptions made explicit.
+
+| Script | Mirrors | Does |
+|---|---|---|
+| `00-preflight.sh <env>` | — | Read-only. Verifies tools, auth, ADC, arch, secrets. Changes nothing. |
+| `05-create-app-secrets.sh <env>` | — | One-time. Creates `whatsapp-app-secret-{aa,pp}`. |
+| `10-build-push.sh <env> [--latest] [--frontend]` | `build-and-push.yml` | Builds `linux/amd64` images, pushes to the NPE registry. |
+| `20-infra.sh <env> plan\|apply` | `deploy.yaml` | `terragrunt run --all`. |
+| `30-agents.sh <env>` | `deploy-agents.yml` | Deploys the two Agent Engines, seeds the engine-name secrets. |
+| `40-redeploy-webhook.sh <env> [sha]` | — | Pins Cloud Run to an image tag; prints the rollback command. |
+
+`<env>` is always the **stack** name — `dev` or `prd`.
+
+## Order
+
+```bash
+./scripts/local-deploy/00-preflight.sh        dev   # fix everything it flags
+./scripts/local-deploy/05-create-app-secrets.sh dev # once per project
+./scripts/local-deploy/10-build-push.sh       dev
+./scripts/local-deploy/20-infra.sh            dev plan    # READ THE PLAN
+./scripts/local-deploy/20-infra.sh            dev apply
+./scripts/local-deploy/30-agents.sh           dev   # MUST precede real traffic
+./scripts/local-deploy/40-redeploy-webhook.sh dev
+```
+
+Steps 20 → 30 → 40 are order-critical. `20` creates
+`engine-{aa,pp}-resource-name` as **empty** secrets; the webhook reads them on
+every inbound message, so between `20` and `30` it returns 500 for everything.
+Do not expose the endpoint until `30` reports both secrets seeded.
+
+## Three names for one environment
+
+The repo is inconsistent about this and it is the easiest way to deploy to the
+wrong project. `lib.sh` resolves it centrally so no script takes a raw name:
+
+| stack dir | `environment.name` | GCP project | `deploy.py --env` | Cloud Run service | image project |
+|---|---|---|---|---|---|
+| `dev` | `dev` | `agro-extension-digital-npe` | `npe` | `agent-webhook-dev` | npe |
+| `prd` | `prd` | `agro-extension-digital-prd` | `prd` | `agent-webhook-prd` | **npe** |
+
+Images live in **NPE for both environments** — prd Cloud Run pulls from the NPE
+registry. Pushing to a prd registry produces an image nothing will ever pull.
+
+## Gotchas these scripts already handle
+
+- **`--platform linux/amd64`.** Cloud Run is amd64-only. A native build on Apple
+  Silicon pushes fine and then fails to start with an exec-format error.
+- **Terragrunt syntax drift.** `--terragrunt-non-interactive` was removed in
+  0.78+; `run-all` is now the deprecated alias for `run --all`. The workflow's
+  command line fails verbatim on a current install (locally: 0.99.4).
+- **`run --all apply` is auto-approve by default.** `--no-auto-approve` is what
+  restores the prompt. Running locally there is no GitHub Environment reviewer
+  gate, so the plan review is the only gate.
+- **ADC ≠ `gcloud auth login`.** `deploy.py` uses Application Default
+  Credentials; without `gcloud auth application-default login` it dies with
+  `DefaultCredentialsError` even though gcloud itself works.
+- **`:latest` does not redeploy.** Cloud Run pins a digest at deploy time.
+- **Plan-time secret reads.** The stacks call `run_cmd` on four secrets while
+  *evaluating* config, so a missing one fails before any plan output, with an
+  error that blames gcloud rather than the real cause.
+- **No trailing newline in secrets.** `printf '%s'`, never `echo` — a trailing
+  `\n` becomes part of the HMAC key and every signature check fails.
+
+## Ambient state
+
+Scripts set `CLOUDSDK_CORE_PROJECT` for their own shell rather than running
+`gcloud config set project`, so your ambient gcloud config is never mutated.
+They use your own credentials — no service-account key is needed or fetched.

--- a/scripts/local-deploy/lib.sh
+++ b/scripts/local-deploy/lib.sh
@@ -86,7 +86,21 @@ confirm_prd() {
 # Make sure gcloud is pointed at the project we think it is, for this shell only.
 # Uses CLOUDSDK_CORE_PROJECT rather than `gcloud config set project` so we never
 # mutate the user's ambient gcloud state.
+#
+# USER_PROJECT_OVERRIDE + GOOGLE_BILLING_PROJECT: the CI workflows authenticate
+# with a service-account key, whose credential carries its own project. Locally
+# we use USER Application Default Credentials, and some APIs the stack touches —
+# firebaserules.googleapis.com in the database unit above all — reject a user
+# credential that carries no quota/billing project, attributing the call to
+# Google's shared default project (32555940559) where the API is disabled:
+#   Error 403 ... requires a quota project, which is not set by default
+# The hashicorp/google provider only sends the X-Goog-User-Project header (which
+# carries the billing project) when user_project_override is true. The provider
+# blocks here don't set it, but the provider also reads these two env vars, so
+# we set them centrally rather than editing every module. Harmless with SA creds.
 use_project() {
   export CLOUDSDK_CORE_PROJECT="$PROJECT_ID"
   export GOOGLE_CLOUD_PROJECT="$PROJECT_ID"
+  export USER_PROJECT_OVERRIDE="true"
+  export GOOGLE_BILLING_PROJECT="$PROJECT_ID"
 }

--- a/scripts/local-deploy/lib.sh
+++ b/scripts/local-deploy/lib.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Shared environment resolution for the local deploy scripts.
+#
+# WHY THIS FILE EXISTS: this repo uses three different names for the same
+# environment, and mixing them up is the easiest way to deploy prod code to the
+# wrong project (or push a prd image into a registry nothing pulls from):
+#
+#   stack dir │ environment.name │ GCP project                  │ deploy.py --env
+#   ──────────┼──────────────────┼──────────────────────────────┼────────────────
+#   dev       │ dev              │ agro-extension-digital-npe   │ npe
+#   prd       │ prd              │ agro-extension-digital-prd   │ prd
+#
+# Container images live in the NPE project for BOTH environments
+# (cicd/stacks/common.yaml → containers.project), because that is the path the
+# backend Terraform points Cloud Run at in dev *and* prd. Never push to the prd
+# registry — nothing pulls from there.
+#
+# Source this, don't run it:  source "$(dirname "$0")/lib.sh"; resolve_env "$1"
+
+set -euo pipefail
+
+REGION="us-central1"
+IMAGE_PROJECT="agro-extension-digital-npe"
+WEBHOOK_IMAGE="${REGION}-docker.pkg.dev/${IMAGE_PROJECT}/agro-extension-digital/webhook"
+FRONTEND_IMAGE="${REGION}-docker.pkg.dev/${IMAGE_PROJECT}/agents/agent-frontend-app"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+# Secrets that must ALREADY exist before `terragrunt plan` runs. The stack reads
+# them with run_cmd at plan time, so a missing one is a hard plan failure, not a
+# runtime problem. Terraform creates the other secrets (datastore-*, engine-*).
+PREEXISTING_SECRETS=(
+  wsp-token
+  webhook-verify-token
+  whatsapp-app-secret-aa
+  whatsapp-app-secret-pp
+)
+
+c_red()  { printf '\033[0;31m%s\033[0m\n' "$*"; }
+c_grn()  { printf '\033[0;32m%s\033[0m\n' "$*"; }
+c_ylw()  { printf '\033[1;33m%s\033[0m\n' "$*"; }
+c_blu()  { printf '\033[0;34m%s\033[0m\n' "$*"; }
+die()    { c_red "❌ $*"; exit 1; }
+
+# resolve_env <dev|prd> — exports STACK, ENV_NAME, PROJECT_ID, AGENT_ENV,
+# CLOUD_RUN_WEBHOOK.
+resolve_env() {
+  local stack="${1:-}"
+  case "$stack" in
+    dev)
+      STACK="dev"; ENV_NAME="dev"
+      PROJECT_ID="agro-extension-digital-npe"
+      AGENT_ENV="npe"
+      ;;
+    prd)
+      STACK="prd"; ENV_NAME="prd"
+      PROJECT_ID="agro-extension-digital-prd"
+      AGENT_ENV="prd"
+      ;;
+    *)
+      die "Usage: $(basename "${0}") <dev|prd>   (got: '${stack}')"
+      ;;
+  esac
+  CLOUD_RUN_WEBHOOK="agent-webhook-${ENV_NAME}"
+  export STACK ENV_NAME PROJECT_ID AGENT_ENV CLOUD_RUN_WEBHOOK
+}
+
+# Print the resolved target so every script states plainly what it will touch.
+print_target() {
+  c_blu "──────────────────────────────────────────────"
+  echo  "  stack dir      : cicd/stacks/${STACK}"
+  echo  "  GCP project    : ${PROJECT_ID}"
+  echo  "  deploy.py --env: ${AGENT_ENV}"
+  echo  "  Cloud Run      : ${CLOUD_RUN_WEBHOOK} (${REGION})"
+  echo  "  image registry : ${IMAGE_PROJECT}"
+  c_blu "──────────────────────────────────────────────"
+}
+
+# Refuse to touch prd without an explicit typed confirmation.
+confirm_prd() {
+  [[ "$STACK" == "prd" ]] || return 0
+  c_ylw "⚠️  TARGET IS PRODUCTION (${PROJECT_ID})."
+  read -r -p "Type 'deploy prd' to continue: " reply
+  [[ "$reply" == "deploy prd" ]] || die "Aborted."
+}
+
+# Make sure gcloud is pointed at the project we think it is, for this shell only.
+# Uses CLOUDSDK_CORE_PROJECT rather than `gcloud config set project` so we never
+# mutate the user's ambient gcloud state.
+use_project() {
+  export CLOUDSDK_CORE_PROJECT="$PROJECT_ID"
+  export GOOGLE_CLOUD_PROJECT="$PROJECT_ID"
+}


### PR DESCRIPTION
The self-hosted runner is not picking up jobs — `build` on #43 sits **queued** (not running), and no runners are registered. So `deploy.yaml`, `deploy-agents.yml` and `build-and-push.yml` all queue indefinitely. This makes local the primary deploy path.

Adds `scripts/local-deploy/`, one script per workflow plus a read-only preflight:

| Script | Mirrors |
|---|---|
| `00-preflight.sh <env>` | — (read-only: tools, auth, ADC, arch, secrets) |
| `05-create-app-secrets.sh <env>` | — (one-time `whatsapp-app-secret-{aa,pp}`) |
| `10-build-push.sh <env>` | `build-and-push.yml` |
| `20-infra.sh <env> plan\|apply` | `deploy.yaml` |
| `30-agents.sh <env>` | `deploy-agents.yml` |
| `40-redeploy-webhook.sh <env>` | — (pin Cloud Run to a tag; prints rollback) |

## What this encodes that the workflows leave implicit

- **Three names per environment.** The `dev` stack targets the **npe** project, `deploy.py` takes `npe`, but the Cloud Run service is `agent-webhook-dev`. `lib.sh` resolves it centrally so no script takes a raw env name.
- **Images live in the NPE registry for both environments.** The runbook's local fallback pushed prd images to a prd registry nothing pulls from.
- **`--platform linux/amd64` is mandatory.** Cloud Run is amd64-only; a native build on Apple Silicon pushes fine and then fails to start with an exec-format error.
- **Terragrunt syntax drift.** `--terragrunt-non-interactive` was removed in 0.78+ and `run-all` is now the deprecated alias for `run --all`. The workflow's command line fails verbatim on a current install (locally 0.99.4 → `flag provided but not defined`). **`deploy.yaml` is worth fixing separately.**
- **`run --all apply` is auto-approve by default.** `--no-auto-approve` restores the prompt. Run locally there is no GitHub Environment reviewer gate, so plan review is the only gate — the script forces it and refuses prd without a typed confirmation.
- **ADC ≠ `gcloud auth login`.** `deploy.py` needs `application-default login` or dies with `DefaultCredentialsError`.
- **Plan-time secret reads.** The stacks `run_cmd` four secrets while *evaluating* config, so a missing one fails before any plan output with an error blaming gcloud.
- **Ordering.** `20` creates `engine-{aa,pp}-resource-name` **empty**; the webhook reads them per message, so it 500s until `30` seeds them. `40` refuses to deploy until they have versions.

## Runbook corrections

`terraform 1.15+` / `terragrunt 1.0+` (neither version exists; `required_version` is `>= 1.5`), the missing `whatsapp-app-secret-{aa,pp}` prerequisite from #47, and the uniform `<env>` substitution.

## Preflight output today

Both environments pass everything except the two app secrets from #47:

- **npe** — ❌ `whatsapp-app-secret-{aa,pp}`; the six `datastore-*`/`bigquery-dataset` secrets absent (expected pre-apply); `engine-{aa,pp}-resource-name` already seeded.
- **prd** — ❌ same two; all Terraform-managed secrets absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WysTn7doFyzq3QTncALfRD