### PR TITLE
docs(producto): Agente PP WhatsApp — épicas e historias de usuario (#50)

### DIFF
--- a/docs/producto/agente-whatsapp/01-vision-producto.md
+++ b/docs/producto/agente-whatsapp/01-vision-producto.md
@@ -1,0 +1,69 @@
+# 01 · Visión de producto
+
+## El problema
+
+Certificarse cuesta esfuerzo administrativo que el productor no siempre tiene. Hoy, para
+saber cómo va, resolver una duda del estándar o cargar una evidencia, tiene que **entrar
+a una plataforma web**, buscar la acción correcta y llenar formularios — muchas veces
+desde el campo, con el celular, las manos ocupadas y poca paciencia. El resultado: la
+evidencia se genera en el predio pero se sube tarde (o no se sube), las dudas quedan sin
+responder y el avance se estanca.
+
+## La promesa
+
+> **Todo lo que el productor necesita para avanzar en su certificación, resuelto por
+> WhatsApp — el canal que ya usa todos los días — con la seguridad de que nada se guarda
+> sin que él lo confirme.**
+
+El productor le escribe (o le manda un audio) a un número de WhatsApp y el copiloto:
+
+- le dice **cómo va** y qué le falta,
+- le **resuelve dudas** del estándar y del proceso, con contexto de *su* expediente,
+- le **recibe evidencia** desde el celular,
+- le **registra sus labores** dictándolas por voz,
+- le **avisa** cuando algo importante cambia.
+
+## Para quién
+
+El **productor de ciruela (PP)** que está en un proceso de certificación — y, de rebote,
+la **encargada de certificación** que acompaña a varios productores. Ver
+[Personas](02-personas.md).
+
+## Por qué ahora
+
+- El canal ya existe y el productor ya lo usa: WhatsApp con texto y audio ya funcionan.
+- El expediente digital del productor (autodiagnóstico, plan, evidencias) ya está en la
+  plataforma. El copiloto no inventa datos: **trabaja sobre el mismo expediente** que la
+  web.
+
+## Métricas de éxito
+
+| Métrica | Qué nos dice |
+|---------|--------------|
+| % de evidencias cargadas por WhatsApp vs. web | Adopción real del canal |
+| Tiempo entre generar la evidencia y cargarla | Si acortamos la fricción |
+| Consultas resueltas sin intervención humana | Autoservicio efectivo |
+| Registros de labores por audio vs. texto | Valor de la captura por voz |
+| Productores que suben de nivel en la temporada | Impacto en el objetivo real |
+
+## Principios de producto
+
+1. **El productor confirma antes de cada acción.** El copiloto **propone**, el productor
+   **confirma**, y recién ahí se guarda. Nunca escribe algo que el productor no aprobó.
+2. **Un solo expediente.** Lo que se hace por WhatsApp es indistinguible de lo que se hace
+   por la web: la misma evidencia, el mismo avance, la misma acción.
+3. **Nunca asume el contexto.** Si el productor tiene más de una empresa o instalación, el
+   copiloto pregunta de cuál se habla antes de responder o guardar.
+4. **Consentimiento y control.** El productor decide vincular su número, sabe qué datos se
+   usan y puede dejar de recibir avisos cuando quiera.
+5. **Referencial, no vinculante.** Cualquier proyección de nivel de certificación se
+   comunica como estimación, no como resultado oficial.
+
+## Fuera de alcance (esta fase)
+
+- Revisión humana del auditor sobre lo que carga el agente.
+- Mensajes y visitas del auditor como notificación.
+- Derivar la conversación al canal humano empresa↔auditor.
+- Unificar los dos agentes (AA / PP) en un solo número.
+
+Estas piezas no se descartan: se abordan en una fase posterior.

--- a/docs/producto/agente-whatsapp/02-personas.md
+++ b/docs/producto/agente-whatsapp/02-personas.md
@@ -1,0 +1,43 @@
+# 02 · Personas
+
+## Primaria — Benjamín, el productor PP
+
+**Productor de ciruela en proceso de certificación.**
+
+- **Contexto.** Trabaja en el predio la mayor parte del día. Su oficina es el celular.
+  Usa WhatsApp para todo — familia, comprador, cuadrilla — y manda audios más que texto
+  porque muchas veces tiene las manos ocupadas o sucias.
+- **A veces maneja más de una empresa o instalación** (varios predios). No siempre tiene
+  claro "a cuál" corresponde cada trámite.
+- **Objetivos.**
+  - Certificarse sin que le quite tiempo de terreno.
+  - Saber, en un vistazo, cómo va y qué le falta.
+  - Dejar la evidencia registrada apenas la genera, sin volver a la casa a subirla.
+- **Frustraciones.**
+  - Entrar a la plataforma web desde el celular es lento y engorroso.
+  - No sabe qué evidencia pide cada acción ni dónde subirla.
+  - Junta las fotos "para después" y después se pierden.
+  - Le da miedo cargar algo en el lugar equivocado.
+- **Cómo lo ayuda el copiloto.** Le responde en WhatsApp, le acepta la foto o el audio en
+  el momento, y **le confirma a qué acción va antes de guardar** — así no se equivoca.
+- **Frase que lo resume.** *"Si me lo puede resolver por WhatsApp, lo hago; si tengo que
+  entrar a la página, lo dejo para después."*
+
+## Secundaria — Claudia, la encargada de certificación
+
+**Acompaña a varios productores en su certificación.**
+
+- **Contexto.** Coordina a varios productores a la vez; necesita que ellos avancen sin
+  tener que estar detrás de cada uno.
+- **Objetivos.** Que sus productores resuelvan dudas y carguen evidencia por su cuenta;
+  que el avance sea real y esté al día.
+- **Frustraciones.** Termina respondiendo por teléfono las mismas dudas del estándar;
+  persigue a los productores para que suban lo que ya tienen en el celular.
+- **Cómo la ayuda el copiloto.** Reduce las consultas repetidas y hace que la evidencia
+  entre sola; ella ve el mismo expediente actualizado en la plataforma.
+
+## Mencionado — el Auditor *(fuera de alcance esta fase)*
+
+Revisa y valida lo que el productor presenta. En esta fase **no participa** del flujo del
+agente: lo que se carga queda registrado y su revisión se reconecta más adelante. Se
+nombra aquí solo para dejar el límite claro.

--- a/docs/producto/agente-whatsapp/03-epicas.md
+++ b/docs/producto/agente-whatsapp/03-epicas.md
@@ -1,0 +1,62 @@
+# 03 · Épicas
+
+Siete apuestas de valor. Cada una agrupa historias de usuario ([ver 04](04-historias-de-usuario.md))
+y entrega valor por sí sola una vez que existe la vinculación (E1).
+
+---
+
+## E1 · Vincular mi WhatsApp con mi cuenta
+**Habilitador — bloquea a todas las demás.**
+
+- **Objetivo.** Que el copiloto sepa con quién habla: su empresa, su instalación, su
+  avance — con el consentimiento del productor.
+- **Valor.** Sin esto, el copiloto solo puede responder en genérico. Con esto, todo pasa a
+  ser "para *tu* acción, con *tu* avance".
+- **Éxito de la épica.** Un productor puede vincular su número en minutos y, a partir de
+  ahí, el copiloto le habla de su expediente. Un número sin vincular nunca ve datos.
+- **Fuera de alcance.** Gestionar permisos entre varios usuarios de una misma empresa.
+
+## E2 · Resolver mis dudas de certificación
+- **Objetivo.** Responder dudas del estándar y del proceso, situadas en el expediente del
+  productor, no en abstracto.
+- **Valor.** El productor deja de esperar a la encargada para entender qué le piden.
+- **Éxito.** La mayoría de las dudas se resuelven en la conversación, citando la acción
+  concreta, tras confirmar de qué empresa/instalación se habla.
+
+## E3 · Saber cómo voy
+- **Objetivo.** Que el productor sepa, cuando quiera, su avance y qué acciones tiene
+  pendientes.
+- **Valor.** Convierte "no sé por dónde voy" en "me faltan estas tres cosas".
+- **Éxito.** El productor pregunta "¿cómo voy?" y recibe su avance (referencial) y sus
+  pendientes de la empresa/instalación confirmada.
+
+## E4 · Cargar evidencia desde el celular
+- **Objetivo.** Recibir fotos y documentos como evidencia, ligados a la acción correcta.
+- **Valor.** La evidencia se sube apenas se genera, sin volver a la plataforma.
+- **Éxito.** Una foto por WhatsApp queda registrada en la acción **que el productor
+  confirmó**, igual que si la hubiera subido por la web.
+- **Regla clave.** La evidencia siempre va ligada a una acción; si el copiloto no sabe a
+  cuál, pregunta — nunca la guarda suelta.
+
+## E5 · Registrar mis labores hablando
+- **Objetivo.** Que el productor deje registro de una labor (riego, aplicación, etc.)
+  dictándola por voz o texto.
+- **Valor.** Captura en terreno, sin escribir formularios; la funcionalidad más nueva y la
+  que menos fricción tiene para el productor.
+- **Éxito.** Un audio se convierte en un registro estructurado que el productor **confirma
+  antes de guardar**; si falta un dato, el copiloto lo pide.
+
+## E6 · Recibir recomendaciones de capacitación
+- **Objetivo.** Recomendar la guía o el curso **de la acción específica** que el productor
+  tiene que resolver.
+- **Valor.** El productor no solo sabe qué le falta, también cómo aprenderlo.
+- **Éxito.** Ante una acción pendiente, el copiloto ofrece el material puntual de esa
+  acción, no una búsqueda genérica.
+
+## E7 · Enterarme de lo importante sin entrar a la plataforma
+- **Objetivo.** Avisar por WhatsApp cuando cambia el nivel proyectado o se acerca un
+  vencimiento.
+- **Valor.** El productor reacciona a tiempo sin tener que estar revisando.
+- **Éxito.** Un cambio de nivel o un vencimiento próximo llega como aviso por WhatsApp,
+  como estimación referencial, y el productor puede desactivarlos.
+- **Fuera de alcance (esta fase).** Avisos de mensajes o visitas del auditor.

--- a/docs/producto/agente-whatsapp/04-historias-de-usuario.md
+++ b/docs/producto/agente-whatsapp/04-historias-de-usuario.md
@@ -1,0 +1,194 @@
+# 04 · Historias de usuario
+
+Formato: **Como** [persona] **quiero** [algo] **para** [beneficio], con criterios de
+aceptación en *Dado / Cuando / Entonces*. Todo en lenguaje de producto: sin detalles
+técnicos. La prioridad y el release están en el [backlog](05-backlog-y-roadmap.md).
+
+> Convención transversal: "el copiloto" = el asistente de WhatsApp. "El expediente" = los
+> datos de certificación del productor (avance, acciones, evidencias).
+
+---
+
+## E1 · Vincular mi WhatsApp con mi cuenta
+
+### HU-01.1 · Vincular mi número
+**Como** productor **quiero** conectar mi WhatsApp con mi cuenta **para** que el copiloto
+conozca mi empresa y mi avance.
+
+- **Dado** que tengo una cuenta en la plataforma, **cuando** pido vincular mi WhatsApp,
+  **entonces** recibo un código y, al enviarlo desde mi número, quedo vinculado.
+- **Dado** que envié el código, **cuando** la vinculación se completa, **entonces** el
+  copiloto me saluda por mi nombre y me dice de qué empresa(s) puede hablar.
+- **Dado** un código vencido o equivocado, **cuando** lo envío, **entonces** el copiloto me
+  lo dice y me ofrece generar uno nuevo.
+
+### HU-01.2 · Aceptar el uso de mis datos
+**Como** productor **quiero** saber y aceptar qué datos se usan **para** vincularme con
+confianza.
+
+- **Dado** que estoy por vincularme, **cuando** se me pide consentimiento, **entonces** veo
+  en lenguaje simple qué información usará el copiloto y tengo que aceptarlo para continuar.
+- **Dado** que ya acepté, **cuando** quiero, **entonces** puedo revocar el consentimiento y
+  el copiloto deja de acceder a mi expediente.
+
+### HU-01.3 · Un número sin vincular no ve datos
+**Como** productor no vinculado **quiero** que el copiloto no muestre datos de nadie
+**para** estar seguro de que mi información está protegida.
+
+- **Dado** un número no vinculado, **cuando** escribe pidiendo su avance o su evidencia,
+  **entonces** el copiloto **no** muestra datos del expediente y explica cómo vincularse.
+
+---
+
+## E2 · Resolver mis dudas de certificación
+
+### HU-02.1 · Preguntar qué exige una acción
+**Como** productor **quiero** preguntar qué evidencia o requisito pide una acción **para**
+saber qué tengo que hacer.
+
+- **Dado** que estoy vinculado, **cuando** pregunto por una acción, **entonces** el copiloto
+  responde citando el código de la acción (p. ej. "A001").
+- **Dado** que la respuesta depende del estándar, **cuando** respondo, **entonces** la
+  respuesta corresponde al estándar de la instalación que confirmé (ver HU-02.3).
+
+### HU-02.2 · Preguntar por nota de voz
+**Como** productor con las manos ocupadas **quiero** preguntar por audio **para** no tener
+que escribir.
+
+- **Dado** que mando un audio con mi duda, **cuando** el copiloto lo recibe, **entonces**
+  responde como si lo hubiera escrito.
+
+### HU-02.3 · Confirmar de qué empresa/instalación hablo
+**Como** productor con más de una empresa o instalación **quiero** que el copiloto confirme
+de cuál se trata **para** no recibir una respuesta del predio equivocado.
+
+- **Dado** que tengo más de una empresa/instalación/estándar, **cuando** hago una consulta,
+  **entonces** el copiloto me pregunta a cuál se refiere **antes** de responder.
+- **Dado** que tengo una sola, **cuando** consulto, **entonces** el copiloto la muestra
+  pre-seleccionada y me pide un ok rápido.
+- **Dado** que aún no confirmé el contexto, **cuando** insisto, **entonces** el copiloto no
+  responde con datos de un contexto sin confirmar.
+
+### HU-02.4 · Reformular si no me sirvió
+**Como** productor **quiero** decir "no me quedó claro" **para** recibir otra explicación
+sin empezar de cero.
+
+- **Dado** que recibí una respuesta, **cuando** digo que no me sirvió, **entonces** el
+  copiloto reformula o pide precisar, sin perder el contexto ya confirmado.
+
+---
+
+## E3 · Saber cómo voy
+
+### HU-03.1 · Ver mi avance
+**Como** productor **quiero** preguntar cómo voy **para** saber cuánto me falta.
+
+- **Dado** el contexto confirmado, **cuando** pregunto "¿cómo voy?", **entonces** el
+  copiloto me da mi avance de esa empresa/instalación, indicado como **referencial**.
+
+### HU-03.2 · Ver mis acciones pendientes
+**Como** productor **quiero** saber qué acciones tengo pendientes **para** priorizar.
+
+- **Dado** el contexto confirmado, **cuando** pido mis pendientes, **entonces** el copiloto
+  lista las acciones que me faltan, con su código, ordenadas de forma útil.
+
+---
+
+## E4 · Cargar evidencia desde el celular
+
+### HU-04.1 · Subir una foto o documento
+**Como** productor **quiero** mandar una foto como evidencia **para** no entrar a la web.
+
+- **Dado** que mando una foto (incluidas las de iPhone) o un documento, **cuando** el
+  copiloto la recibe, **entonces** la acepta y avanza a confirmar el destino (HU-04.2).
+- **Dado** un archivo no válido (muy pesado o de tipo no permitido), **cuando** lo mando,
+  **entonces** el copiloto me explica qué pasó y qué mandar en su lugar.
+
+### HU-04.2 · Confirmar a qué acción va antes de guardar
+**Como** productor **quiero** ver a qué empresa/instalación/acción se va a guardar y
+confirmarlo **para** no equivocarme.
+
+- **Dado** que mandé una evidencia, **cuando** el copiloto identifica el destino,
+  **entonces** me muestra un resumen (empresa · instalación · acción) y me pide confirmar.
+- **Dado** que confirmo, **cuando** doy el ok, **entonces** la evidencia queda registrada en
+  esa acción y el copiloto me lo avisa.
+- **Dado** que el copiloto no logra determinar la acción, **cuando** recibe la evidencia,
+  **entonces** me pregunta a cuál va — nunca la guarda suelta.
+
+### HU-04.3 · Corregir el destino
+**Como** productor **quiero** corregir la acción si el copiloto eligió mal **para** que
+quede en el lugar correcto.
+
+- **Dado** el resumen de destino, **cuando** digo que no es esa acción, **entonces** el
+  copiloto me deja indicar la correcta y vuelve a pedir confirmación.
+
+### HU-04.4 · Confirmación de que quedó guardada
+**Como** productor **quiero** una confirmación clara **para** saber que ya no tengo que
+volver a subirla.
+
+- **Dado** que confirmé, **cuando** la evidencia se guarda, **entonces** recibo un mensaje
+  que dice a qué acción quedó ligada.
+
+---
+
+## E5 · Registrar mis labores hablando
+
+### HU-05.1 · Registrar una labor por voz
+**Como** productor **quiero** contar por audio qué hice **para** dejar el registro sin
+escribir.
+
+- **Dado** que mando un audio describiendo una labor, **cuando** el copiloto lo procesa,
+  **entonces** arma un resumen ordenado de la labor (cuartel, producto, dosis, etc.) y me
+  lo presenta.
+
+### HU-05.2 · Confirmar el registro antes de guardar
+**Como** productor **quiero** revisar el resumen y confirmarlo **para** que no se guarde
+algo mal entendido.
+
+- **Dado** un resumen de la labor, **cuando** el copiloto me lo lee, **entonces** solo lo
+  guarda si yo confirmo.
+- **Dado** que algo está mal, **cuando** lo corrijo, **entonces** el copiloto ajusta el
+  resumen y vuelve a pedir confirmación.
+
+### HU-05.3 · Completar datos faltantes
+**Como** productor **quiero** que el copiloto me pida lo que falta **para** no dejar un
+registro a medias.
+
+- **Dado** que en mi audio falta un dato obligatorio (p. ej. cuártel o dosis), **cuando** el
+  copiloto arma el resumen, **entonces** me pregunta ese dato antes de poder guardar; nunca
+  registra incompleto.
+
+---
+
+## E6 · Recibir recomendaciones de capacitación
+
+### HU-06.1 · Recomendación por acción
+**Como** productor **quiero** que me recomiende el material de la acción específica
+**para** aprender a resolverla.
+
+- **Dado** que tengo una acción pendiente o pregunto por ella, **cuando** pido ayuda,
+  **entonces** el copiloto me ofrece la guía/curso **de esa acción**, no una lista genérica.
+
+---
+
+## E7 · Enterarme de lo importante
+
+### HU-07.1 · Aviso de cambio de nivel
+**Como** productor **quiero** enterarme si mi nivel proyectado cambia **para** reaccionar a
+tiempo.
+
+- **Dado** que estoy vinculado y con avisos activos, **cuando** mi nivel proyectado cambia,
+  **entonces** recibo un aviso por WhatsApp, indicado como **referencial**.
+
+### HU-07.2 · Aviso de vencimiento próximo
+**Como** productor **quiero** que me avisen cuando una acción está por vencer **para** no
+dejarla pasar.
+
+- **Dado** que tengo una acción con fecha próxima, **cuando** se acerca el vencimiento,
+  **entonces** recibo un aviso a tiempo con la acción concreta.
+
+### HU-07.3 · Desactivar los avisos
+**Como** productor **quiero** poder dejar de recibir avisos **para** no sentirme invadido.
+
+- **Dado** que recibo avisos, **cuando** pido no recibir más, **entonces** el copiloto deja
+  de enviarlos y me confirma que quedó desactivado.

--- a/docs/producto/agente-whatsapp/05-backlog-y-roadmap.md
+++ b/docs/producto/agente-whatsapp/05-backlog-y-roadmap.md
@@ -1,0 +1,70 @@
+# 05 · Backlog priorizado y roadmap
+
+## Backlog priorizado
+
+Prioridad en **MoSCoW** (Must / Should / Could). Estimación en tallas de camiseta
+(S/M/L) como referencia gruesa de tamaño, no de tiempo. "Depende de" señala qué tiene que
+estar antes.
+
+| Historia | Épica | Prioridad | Talla | Depende de |
+|----------|-------|-----------|:-----:|-----------|
+| HU-01.1 Vincular mi número | E1 | Must | M | — |
+| HU-01.2 Aceptar el uso de mis datos | E1 | Must | S | — |
+| HU-01.3 Sin vínculo no ve datos | E1 | Must | S | — |
+| HU-02.3 Confirmar de qué empresa hablo | E2 | Must | M | E1 |
+| HU-03.1 Ver mi avance | E3 | Must | S | E1, HU-02.3 |
+| HU-03.2 Ver acciones pendientes | E3 | Must | S | E1, HU-02.3 |
+| HU-02.1 Preguntar qué exige una acción | E2 | Must | M | E1 |
+| HU-02.2 Preguntar por nota de voz | E2 | Should | S | HU-02.1 |
+| HU-02.4 Reformular si no me sirvió | E2 | Should | S | HU-02.1 |
+| HU-04.1 Subir una foto o documento | E4 | Must | M | E1 |
+| HU-04.2 Confirmar el destino antes de guardar | E4 | Must | M | HU-04.1 |
+| HU-04.3 Corregir el destino | E4 | Should | S | HU-04.2 |
+| HU-04.4 Confirmación de guardado | E4 | Must | S | HU-04.2 |
+| HU-05.1 Registrar labor por voz | E5 | Must | L | E1 |
+| HU-05.2 Confirmar antes de guardar | E5 | Must | M | HU-05.1 |
+| HU-05.3 Completar datos faltantes | E5 | Must | M | HU-05.1 |
+| HU-06.1 Recomendación por acción | E6 | Could | M | E3 |
+| HU-07.1 Aviso de cambio de nivel | E7 | Should | M | E1 |
+| HU-07.2 Aviso de vencimiento próximo | E7 | Should | M | E1 |
+| HU-07.3 Desactivar los avisos | E7 | Must* | S | HU-07.1 |
+
+\* *Must dentro de E7*: si hay avisos, tiene que haber opt-out. Si E7 no entra en esta
+fase, HU-07.3 tampoco.
+
+## Roadmap por releases
+
+Cada release es un incremento **usable por sí solo** una vez liberado R1. El orden respeta
+las dependencias: primero conocer al productor, luego leerle el expediente, luego
+escribirlo, luego enriquecerlo y avisarle.
+
+### R1 · Conóceme *(habilitador)*
+- **Historias:** HU-01.1, HU-01.2, HU-01.3.
+- **Valor entregado:** el productor vincula su número y el copiloto ya sabe con quién
+  habla. Nada personalizado funciona sin esto.
+- **Hito H1:** *productor vinculado y con consentimiento.*
+
+### R2 · Acompáñame *(lectura)*
+- **Historias:** HU-02.3, HU-03.1, HU-03.2, HU-02.1, HU-02.2, HU-02.4.
+- **Valor:** el productor pregunta cómo va, qué le falta y qué exige cada acción — con su
+  contexto confirmado.
+- **Hito H2:** *el copiloto responde sobre el expediente del productor.*
+
+### R3 · Recíbeme la evidencia *(escritura)*
+- **Historias:** HU-04.1, HU-04.2, HU-04.3, HU-04.4.
+- **Valor:** la evidencia se carga desde el celular, ligada a la acción confirmada.
+- **Hito H3:** *evidencia por WhatsApp, indistinguible de la web.*
+
+### R4 · Escúchame *(labores por voz)*
+- **Historias:** HU-05.1, HU-05.2, HU-05.3.
+- **Valor:** el productor registra sus labores dictándolas, confirmando antes de guardar.
+- **Hito H4:** *registro de labores por audio.*
+
+### R5 · Avísame y guíame *(proactividad + aprendizaje)*
+- **Historias:** HU-07.1, HU-07.2, HU-07.3, HU-06.1.
+- **Valor:** el productor se entera de cambios de nivel y vencimientos, y recibe la
+  capacitación puntual de cada acción.
+- **Hito H5:** *avisos proactivos y recomendaciones contextuales.*
+
+> Las fechas se fijan al planificar cada release. Este roadmap ordena por **valor y
+> dependencia**, no por calendario.

--- a/docs/producto/agente-whatsapp/06-listo-y-terminado.md
+++ b/docs/producto/agente-whatsapp/06-listo-y-terminado.md
@@ -1,0 +1,58 @@
+# 06 · Listo y Terminado + glosario
+
+## Definition of Ready — cuándo una historia entra a un sprint
+
+Una historia está **lista** para desarrollarse cuando:
+
+- [ ] Sigue el formato *Como… quiero… para…* y el beneficio es real.
+- [ ] Tiene criterios de aceptación claros en *Dado / Cuando / Entonces*.
+- [ ] Cabe en un sprint (si no, se parte).
+- [ ] Sus dependencias están liberadas o planificadas antes.
+- [ ] Contempla el **paso de confirmación** cuando corresponde (toda acción que escribe algo
+      en el expediente lo hace tras confirmación del productor).
+- [ ] Contempla el caso **multiempresa** (¿qué pasa si el productor tiene más de una
+      empresa/instalación?).
+- [ ] Contempla el **caso de error** visible para el productor (qué mensaje recibe).
+- [ ] El equipo la entiende y la estimó.
+
+## Definition of Done — cuándo una historia está terminada
+
+Una historia está **terminada** cuando:
+
+- [ ] Todos sus criterios de aceptación se cumplen y se probaron.
+- [ ] El flujo funciona por WhatsApp con **texto y audio** (cuando aplica).
+- [ ] **Ninguna escritura ocurre sin confirmación** del productor.
+- [ ] El productor **nunca ve datos de otra empresa**: el contexto se confirma y se respeta.
+- [ ] Los mensajes al productor son claros y en su lenguaje (no jerga del sistema).
+- [ ] Los casos de error tienen un mensaje útil (qué pasó y qué hacer).
+- [ ] Lo que se hace por WhatsApp queda **igual** que si se hubiera hecho por la web.
+- [ ] Se instrumentó lo necesario para medir las métricas de éxito de esa capacidad.
+- [ ] Documentación de producto actualizada si cambió el comportamiento.
+
+## Reglas de negocio transversales
+
+Aplican a todas las historias; no se repiten en cada una.
+
+| ID | Regla |
+|----|-------|
+| RN-1 | La evidencia y los registros **siempre** van ligados a una acción. Si el copiloto no puede determinar a cuál, pregunta; nunca guarda suelto. |
+| RN-2 | Toda proyección de nivel de certificación se comunica como **referencial**, no como resultado oficial. |
+| RN-3 | El copiloto **solo** opera dentro del expediente del número autorizado. Nunca cruza datos entre empresas. |
+| RN-4 | Todo lo que carga el copiloto queda **trazado como originado por WhatsApp**. |
+| RN-5 | Los avisos respetan el **consentimiento** y ofrecen **opt-out**. |
+
+## Glosario
+
+| Término | Qué significa (en palabras del productor) |
+|---------|--------------------------------------------|
+| **Copiloto / agente** | El asistente de WhatsApp que acompaña al productor. |
+| **Expediente** | Todo lo del productor en su certificación: avance, acciones, evidencias, registros. |
+| **Autodiagnóstico** | El cuestionario con el que el productor evalúa su cumplimiento inicial. |
+| **Acción** | Una tarea del plan que el productor debe cumplir (identificada por un código, p. ej. A001). |
+| **Evidencia / medio de verificación** | La foto o documento que prueba que una acción se cumplió. |
+| **Registro de labores** | La bitácora de lo que se hizo en el predio (riego, aplicaciones, etc.). |
+| **Estándar (PP / AA)** | El conjunto de requisitos que aplica según el tipo de instalación (Producción Primaria / Adecuación Agroindustrial). |
+| **Instalación** | Cada predio o unidad del productor. Un productor puede tener varias. |
+| **Nivel de certificación** | El grado de avance/logro proyectado del productor. |
+| **Vinculación** | Conectar el número de WhatsApp del productor con su cuenta. |
+| **Consentimiento** | La aceptación explícita del productor para que el copiloto use sus datos. |

--- a/docs/producto/agente-whatsapp/README.md
+++ b/docs/producto/agente-whatsapp/README.md
@@ -1,0 +1,33 @@
+# Agente PP en WhatsApp — Documentación de producto
+
+Copiloto de certificación por WhatsApp para el productor de ciruela. Deja de ser un
+asistente de preguntas y respuestas y pasa a **acompañar al productor de extremo a
+extremo**: le dice cómo va, le resuelve dudas, le recibe evidencia y le registra sus
+labores — todo por WhatsApp, con **confirmación humana antes de cada acción**.
+
+Esta carpeta es la fuente de verdad **de producto** (el *qué* y el *para quién*). El
+*cómo* técnico vive aparte, en las vistas de arquitectura.
+
+## Mapa de documentos
+
+| # | Documento | Para qué sirve |
+|---|-----------|----------------|
+| 01 | [Visión de producto](01-vision-producto.md) | Problema, promesa, métricas de éxito, principios y alcance de esta fase |
+| 02 | [Personas](02-personas.md) | Para quién construimos y qué le importa |
+| 03 | [Épicas](03-epicas.md) | Las grandes apuestas de valor y qué las compone |
+| 04 | [Historias de usuario](04-historias-de-usuario.md) | Historias con criterios de aceptación (el detalle accionable) |
+| 05 | [Backlog y roadmap](05-backlog-y-roadmap.md) | Prioridad, releases e hitos |
+| 06 | [Listo y Terminado + glosario](06-listo-y-terminado.md) | Definition of Ready / Done y el vocabulario del dominio |
+
+## Cómo leerlo
+
+- **Negocio / stakeholders** → 01 y 03.
+- **Equipo de desarrollo** → 04, 05 y 06 (más las vistas de arquitectura).
+- **Planificación de sprint** → 05 (backlog) + 06 (Definition of Ready).
+
+## Decisión de alcance de esta fase
+
+El **auditor humano queda fuera** de esta fase: no hay revisión, mensajes ni visitas
+del auditor en el flujo del agente. La evidencia y los registros quedan guardados; la
+revisión humana se reconecta en una fase posterior. Todo lo demás del ciclo del
+productor está dentro.


### PR DESCRIPTION
## Qué es

Documentación de **producto** para el Agente PP en WhatsApp (copiloto de certificación),
la contraparte accionable de la discusión #50. En lenguaje de negocio, **sin detalle
técnico** — para alinear alcance y bajar a historias implementables.

## Contenido (`docs/producto/agente-whatsapp/`)

| Doc | Contenido |
|-----|-----------|
| README | Índice y mapa de lectura |
| 01 Visión | Problema, promesa, métricas de éxito, principios, alcance |
| 02 Personas | Benjamín (productor PP) y Claudia (encargada) |
| 03 Épicas | 7 épicas de valor (E1 Vincular … E7 Avisos) |
| 04 Historias | 20 historias `Como… quiero… para…` con criterios `Dado/Cuando/Entonces` |
| 05 Backlog y roadmap | Priorización MoSCoW + 5 releases con hitos |
| 06 Listo y Terminado | Definition of Ready/Done, reglas de negocio y glosario |

## Decisiones de PO embebidas

- **Human-in-the-loop**: ninguna escritura ocurre sin confirmación del productor (criterio de aceptación + DoD).
- **Multiempresa**: caso obligatorio en el Definition of Ready y una historia propia (HU-02.3).
- **Auditor humano fuera de esta fase**: declarado de forma consistente en toda la doc.
- El backlog **ordena por valor y dependencia**, no por calendario.

## Cómo revisar

Empezar por 01 (visión) y 03 (épicas) para el alcance; 04 (historias) para el detalle.
Comentarios sobre prioridades, criterios de aceptación o el corte de releases son bienvenidos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)